### PR TITLE
[CREATED] created building list view + filtering

### DIFF
--- a/offices/tests.py
+++ b/offices/tests.py
@@ -160,3 +160,184 @@ class BuildingViewTest(TestCase):
         self.assertEqual(response.json(), {
             'MESSAGE': 'INVALID_BUILDING_ID'
         })
+
+
+class BuildingListViewTest(TestCase):
+    def setUp(self):
+        self.client = Client()
+
+        building_1 = Building.objects.create(
+            id=1,
+            city        = 'a',
+            district    = 'a',
+            address     = 'a',
+            latitude    = 0,
+            longitude   = 0,
+            name        = 'a',
+            title       = 'a',
+            sub_title   = 'a',
+            description = 'a',
+        )
+
+        BuildingImage.objects.create(
+            name     = 'a',
+            url      = 'a',
+            building = building_1
+        )
+
+        building_2 = Building.objects.create(
+            id=2,
+            city        = 'b',
+            district    = 'b',
+            address     = 'b',
+            latitude    = 0,
+            longitude   = 0,
+            name        = 'b',
+            title       = 'b',
+            sub_title   = 'b',
+            description = 'b',
+        )
+
+        BuildingImage.objects.create(
+            name     = 'b',
+            url      = 'b',
+            building = building_2
+        )
+
+        office_1 = Office.objects.create(
+            name         = 'a',
+            building     = building_1,
+            price        = 1,
+            capacity     = 1,
+            capacity_max = 100,
+            image        = 'a'
+        )
+
+        office_2 = Office.objects.create(
+            name         = 'b',
+            building     = building_2,
+            price        = 2,
+            capacity     = 2,
+            capacity_max = 200,
+            image        = 'b'
+        )
+
+    def tearDown(self):
+        Building.objects.all().delete()
+        Office.objects.all().delete()
+        BuildingImage.objects.all().delete()
+
+    def test_building_list_view_get_method_without_query_without_order_success(self):
+        response  = self.client.get('/buildings')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.json(), {
+            'MESSAGE': 'SUCCESS',
+            'RESULT': {
+                'count': 2,
+                'buildings': [
+                    {
+                        'id'           : 1,
+                        'name'         : 'a',
+                        'city'         : 'a',
+                        'district'     : 'a',
+                        'image'        : 'a',
+                        'min_capacity' : 1,
+                        'max_capacity' : 100,
+                        'min_price'    : '1.00',
+                        'max_price'    : '1.00',
+                        'latitude'     : '0.000000',
+                        'longitude'    : '0.000000',
+                    },
+                    {
+                        'id'           : 2,
+                        'name'         : 'b',
+                        'city'         : 'b',
+                        'district'     : 'b',
+                        'image'        : 'b',
+                        'min_capacity' : 2,
+                        'max_capacity' : 200,
+                        'min_price'    : '2.00',
+                        'max_price'    : '2.00',
+                        'latitude'     : '0.000000',
+                        'longitude'    : '0.000000',
+                    },
+                ]
+            }
+        })
+
+    def test_building_list_view_get_method_with_query_without_order_success(self):
+        response = self.client.get('/buildings?search=a')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.json(), {
+            'MESSAGE': 'SUCCESS',
+            'RESULT': {
+                'count': 1,
+                'buildings': [
+                    {
+                        'id'           : 1,
+                        'name'         : 'a',
+                        'city'         : 'a',
+                        'district'     : 'a',
+                        'image'        : 'a',
+                        'min_capacity' : 1,
+                        'max_capacity' : 100,
+                        'min_price'    : '1.00',
+                        'max_price'    : '1.00',
+                        'latitude'     : '0.000000',
+                        'longitude'    : '0.000000',
+                    },
+                ]
+            }
+        })
+
+
+    def test_building_list_view_get_method_without_query_with_order_success(self):
+        response = self.client.get('/buildings?order-by=price-high')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.json(), {
+            'MESSAGE': 'SUCCESS',
+            'RESULT': {
+                'count': 2,
+                'buildings': [
+                    {
+                        'id'           : 2,
+                        'name'         : 'b',
+                        'city'         : 'b',
+                        'district'     : 'b',
+                        'image'        : 'b',
+                        'min_capacity' : 2,
+                        'max_capacity' : 200,
+                        'min_price'    : '2.00',
+                        'max_price'    : '2.00',
+                        'latitude'     : '0.000000',
+                        'longitude'    : '0.000000',
+                    },
+                    {
+                        'id'           : 1,
+                        'name'         : 'a',
+                        'city'         : 'a',
+                        'district'     : 'a',
+                        'image'        : 'a',
+                        'min_capacity' : 1,
+                        'max_capacity' : 100,
+                        'min_price'    : '1.00',
+                        'max_price'    : '1.00',
+                        'latitude'     : '0.000000',
+                        'longitude'    : '0.000000',
+                    },
+                ]
+            }
+        })
+
+    def test_building_list_view_get_method_with_query_without_order_invalid_filter_error(self):
+        response = self.client.get('/buildings?check-in=2021-12-12&check-out=2022-01-0')
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(response.json(), {'MESSAGE': 'INVALID_FILTER'})

--- a/offices/urls.py
+++ b/offices/urls.py
@@ -1,8 +1,9 @@
-from django.urls import path, include
+from django.urls import path
 
-from offices.views import BuildingView, special_list
+from offices.views import BuildingView, special_list, BuildingListView
 
 urlpatterns = [
+    path('', BuildingListView.as_view()),
     path('/<int:building_id>', BuildingView.as_view()),
     path('/specials', special_list),
 ]

--- a/offices/views.py
+++ b/offices/views.py
@@ -1,10 +1,13 @@
-from django.views        import View
-from django.http         import JsonResponse
-from django.utils        import timezone
-from django.db.models    import Prefetch
+import datetime
 
-from offices.models      import Building, Special
-from reservations.models import Reservation
+from django.views           import View
+from django.http            import JsonResponse
+from django.db.models       import F, Max, Min, Q, Count, Prefetch
+from django.core.exceptions import ValidationError
+from django.utils           import timezone
+
+from offices.models         import Building, Office, Special
+from reservations.models    import Reservation
 
 def special_list(request):
     specials = Special.objects.all()
@@ -82,3 +85,100 @@ class BuildingView(View):
 
         except Building.DoesNotExist:
             return JsonResponse({'MESSAGE': 'INVALID_BUILDING_ID'}, status=404)
+
+
+class BuildingListView(View):
+    def get(self, request):
+        try:
+            data  = request.GET
+
+            orders = {
+                'price-low'      : 'min_price',
+                'price-high'     : '-min_price',
+                'popularity'     : '-popularity',
+                'headcount-low'  : 'min_capacity',
+                'headcount-high' : '-max_capacity'
+            }
+
+            filters = {
+                'special' : 'specials__name__in',
+                'country' : 'country__in',
+                'city'    : 'city__in',
+                'district': 'district__in'
+            }
+
+            limit        = int(data.get('limit', 10) or 10)
+            offset       = int(data.get('offset', 0) or 0)
+            check_in     = data.get('check-in', None)
+            check_out    = data.get('check-out', None)
+            max_price    = int(data.get('max-price', 50000) or 50000)
+            min_price    = int(data.get('min-price', 0) or 0)
+            capacity     = int(data.get('headcount', 10) or 10)
+            order_by     = data.get('order-by', None)
+            order_by     = orders[order_by] if order_by in orders else 'id'
+
+            filter_set   = {
+                filters.get(key): value
+                for (key, value) in dict(request.GET).items()\
+                if filters.get(key) and value != ['']
+            }
+
+            search = data.get('search', None)
+
+            if search:
+                filter_set['name__contains'] = search
+
+            offices = Office.objects.exclude(
+                Q(
+                    Q(reservation__check_out_date__gt=check_in) &
+                    Q(reservation__check_in_date__lte=check_in)
+                ) |
+                Q(reservation__check_in_date__range=[
+                    check_in,
+                    datetime.date.fromisoformat(check_out) - datetime.timedelta(days=1)
+                ])
+            ).values_list('id')\
+            if check_in and check_out else Office.objects.all().values_list('id')
+
+            office_ids = [office[0] for office in offices]
+
+            buildings = Building.objects.filter(
+                office__id__in = office_ids
+            ).distinct().annotate(
+                max_price      = Max(F('office__price')),
+                min_price      = Min(F('office__price')),
+                max_capacity   = Max(F('office__capacity_max')),
+                min_capacity   = Min(F('office__capacity')),
+                popularity     = Count(F('office__reservation')),
+            ).prefetch_related('buildingimage_set').filter(
+                max_price__gte    = min_price,
+                min_price__lte    = max_price,
+                max_capacity__gte = capacity,
+                min_capacity__lte = capacity,
+                **filter_set,
+            ).order_by(order_by)
+
+            result = {
+                'count': buildings.count(),
+                'buildings': [
+                    {
+                        'id'           : building.id,
+                        'name'         : building.name,
+                        'city'         : building.city,
+                        'district'     : building.district,
+                        'image'        : building.buildingimage_set.all()[0].url,
+                        'min_capacity' : building.min_capacity,
+                        'max_capacity' : building.max_capacity,
+                        'min_price'    : building.min_price,
+                        'max_price'    : building.max_price,
+                        'latitude'     : building.latitude,
+                        'longitude'    : building.longitude,
+                    }
+                    for building in buildings[offset:offset+limit]
+                ]
+            }
+
+            return JsonResponse({'MESSAGE': 'SUCCESS', 'RESULT': result}, status=200)
+
+        except ValueError:
+            return JsonResponse({'MESSAGE': 'INVALID_FILTER'}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 빌딩 리스트 GET 메소드 구현

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 도시, 구, 이름, 가격 범위, 체크인, 체크아웃 가능 여부 등으로 필터링 하여 pagination되도록 빌딩 리스트 반환
- 높은/낮은 가격순, 인기순, 높은/낮은 인원수 등으로 order_by 적용

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 체크인/체크아웃을 통해 건물과 사무실 사이에서 예약 가능한 '빌딩'만을 표출할 수 있는 로직에 대해 고민했습니다.
- 다양한 필터들과 정렬로 값이 있을때/없을때 핸들링하는 방식에 대해 생각해봤습니다.
- 잘못된 필터값이 입력될 경우 어떤 방식으로 에러핸들링 할 지 고민해봤습니다.

<br />

## :: TEST RESULT
![스크린샷 2021-12-15 16 36 18](https://user-images.githubusercontent.com/31269150/146143421-2258fe76-71aa-4bb0-b523-410ce59d42e0.png)

